### PR TITLE
fix: Use dynamic tenant in API scope configuration

### DIFF
--- a/frontend/src/authConfig.ts
+++ b/frontend/src/authConfig.ts
@@ -1,17 +1,17 @@
 /* eslint-disable no-console */
 import { Configuration } from '@azure/msal-browser';
 
-
-
 // B2C Endpoints
 const b2cAuth = {
-  tenant: process.env.REACT_APP_B2C_TENANT || "resumematchprodev",
-  clientId: process.env.REACT_APP_FRONTEND_CLIENT_ID || "42517ab6-e124-413b-8e1f-ba4d38e13c9c",
-  authorityDomain: process.env.REACT_APP_B2C_AUTHORITY_DOMAIN || "resumematchprodev.b2clogin.com",
-  backendClientId: process.env.REACT_APP_BACKEND_CLIENT_ID || "50b21c0f-f505-4d30-97f9-033b52e9425c"
+  tenant: process.env.REACT_APP_B2C_TENANT,
+  clientId: process.env.REACT_APP_FRONTEND_CLIENT_ID,
+  authorityDomain: process.env.REACT_APP_B2C_AUTHORITY_DOMAIN,
+  backendClientId: process.env.REACT_APP_BACKEND_CLIENT_ID
 };
 
-
+if (!b2cAuth.tenant || !b2cAuth.clientId || !b2cAuth.authorityDomain || !b2cAuth.backendClientId) {
+  throw new Error('Required B2C configuration is missing');
+}
 
 // Authority URLs
 const authorityBase = `https://${b2cAuth.authorityDomain}/${b2cAuth.tenant}.onmicrosoft.com`;
@@ -36,18 +36,17 @@ if (!baseUrl) {
 
 // Construct redirect URI with trailing slash
 const redirectUri = `${baseUrl}/auth-callback/`;
+
 // API Scopes - separate login and API scopes
 const loginScopes = [
   'openid',
   'profile',
-  'offline_access',
-  b2cAuth.clientId,  // required to get the access token
-  // `https://resumematchprodev.onmicrosoft.com/resumematchpro-api/Files.ReadWrite`
+  'offline_access'
 ];
 
+// Construct API scope using the tenant from environment
 const apiScopes = [
-  // `api://${b2cAuth.backendClientId}/Files.ReadWrite`
-  'https://resumematchprodev.onmicrosoft.com/resumematchpro-api/Files.ReadWrite'
+  `https://${b2cAuth.tenant}.onmicrosoft.com/resumematchpro-api/Files.ReadWrite`
 ];
 
 // MSAL Configuration


### PR DESCRIPTION
- Updated API scope to use dynamic tenant from environment variables - Removed hardcoded fallback values - Added validation for required B2C configuration - All tests passing