### PR TITLE
fix: sort files by matching score in descending order

### DIFF
--- a/frontend/src/components/FilesList/FilesList.tsx
+++ b/frontend/src/components/FilesList/FilesList.tsx
@@ -74,7 +74,11 @@ const FilesList: React.FC<FilesListProps> = ({
         <List
           className={styles.filesList}
           itemLayout="horizontal"
-          dataSource={files}
+          dataSource={files.sort((a, b) => {
+            const scoreA = matchingScores[a.id] || 0;
+            const scoreB = matchingScores[b.id] || 0;
+            return scoreB - scoreA;
+          })}
           locale={{ emptyText: isLoading ? ' ' : 'No files found' }}
           renderItem={file => (
             <List.Item


### PR DESCRIPTION
This PR adds sorting functionality to display matching results in descending order based on their matching scores.